### PR TITLE
Folder permissions will now be checked when inputting the newGamePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Be vigilant of the hex table name `hex_table_{game_version}_{commit_id}.json`, i
 
 * As of `v1.5.6`, the powershell CLI can now install a standalone python version, this can be helpful if you're having issues detecting your install.
 
+* As of `v1.5.10`, when setting the newGamePath, the permissions will be checked to ensure there's less issues when moving the Starfield executable.
+
 ### Misc
 
 * Added a script to auto generate the hex table using the Address Libraries

--- a/docs/README.md
+++ b/docs/README.md
@@ -196,6 +196,15 @@ You'll probably get an error when trying to move `Starfield.exe` manually, if th
 
 You will notice that the icon of the exe will change to the starfield logo, this is good.
 
+If the above fails, you can try:
+
+1. Right-Click > Delete
+2. Open the Recycling bin
+3. Right-Click > Cut
+4. Paste `Starfield.exe` to the target folder (Right-click in folder > paste or `CTRL + V`)
+5. Copy it back to the original game folder
+
+
 <details>
   <summary>Icon:</summary>
 

--- a/scripts/cli.ps1
+++ b/scripts/cli.ps1
@@ -140,7 +140,6 @@ Do {
                 Write-Host "`tStandalone Python: $(getConfigProperty "standalonePython" )"
                 Write-Host "`t"
 
-                Clear-Host
                 Write-Host 
                 "
                     1. Set Paths

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -61,7 +61,7 @@ function writeToConsole() {
         }
 
         if (!$bgcolor) {
-            $bgcolor = "Black"
+                $bgcolor = "Black"
         }
 
         Write-Host $msg -ForegroundColor $color -BackgroundColor $bgcolor
@@ -190,4 +190,33 @@ function runProcessAndLog() {
     logToFile "stdout: $stdout" $logPath
     logToFile "stderr: $stderr" $logPath
     logToFile ("exit code: " + $p.ExitCode) $logPath
+}
+
+function hasPermissions() {
+    param (
+        [Parameter(Mandatory = $true)] [String] $path,
+        [Parameter(Mandatory = $false)] [switch] $checkVersionInfo
+    )
+
+    if (!$path) {
+        return $false
+    }
+
+    # We can check the exe details to determine if we have full access, as it's hidden by default
+    if (!$checkVersionInfo) {
+        # Get current user
+        $user = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+
+        # Quick and dirty check to see if user has FullControl file system rights, returns null if not.
+        $permissions = (Get-Acl $path).Access | Where-Object { $_.IdentityReference -eq $user -and $_.FileSystemRights -eq "FullControl" }
+    }
+    else {
+        $permissions = (Get-Item $path).VersionInfo | Select-Object -ExpandProperty FileDescription
+    }
+
+    if ($permissions) {
+        return $true
+    }
+
+    return $false
 }


### PR DESCRIPTION
This PR addresses the issue mention in #13 , I've added some checks to prevent the user from using a folder without adequate permissions, hopefully mitigating the issue mentioned in the issue thread. This also has some minor bug fixes. 

- Folder permissions will now be checked when inputting the newGamePath

- Starfield EXE permissions will now be checked when moving it to newGamePath

- Fixed a bug that cleared the config page info

- Fixed a bug that allowed users to set the same path for gamePath and newGamePath

- Improved error handling/messages