### PR TITLE
Auto find game install

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
           Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
           Set-PSRepository psgallery -InstallationPolicy trusted
           Install-Module -Name Pester -RequiredVersion 5.6.1 -confirm:$false -Force
+          Install-Module -Name Assert
           Invoke-Pester -Path ./       
         shell: pwsh
 
@@ -36,6 +37,7 @@ jobs:
         Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
         Set-PSRepository psgallery -InstallationPolicy trusted
         Install-Module -Name Pester -RequiredVersion 5.6.1 -Confirm:$false -Force
+        Install-Module -Name Assert
         Invoke-Pester -Path ./
         if ($Error[0].Fullyqualifiederrorid -eq 'PesterAssertionFailed') {exit 1}    
       shell: powershell

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs/
 vswhere.exe
 config.json
 __cmake_systeminformation
+reg/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Be vigilant of the hex table name `hex_table_{game_version}_{commit_id}.json`, i
 
 * As of `v1.5.10`, when setting the newGamePath, the permissions will be checked to ensure there's less issues when moving the Starfield executable.
 
+* As of `v1.6.0`:
+ - The script will now auto find the game install path and update the config
+ - SFSE can now be launched via winstore shortcut without the need to move files/exe to bypass permissions
+  - This option can be enabled/disabled in the script options, if you want to revert to vanilla
+
 ### Misc
 
 * Added a script to auto generate the hex table using the Address Libraries

--- a/docs/compatibility/README.md
+++ b/docs/compatibility/README.md
@@ -2,7 +2,7 @@
 
     Any SFSE Mod utilizing the Address Library should work on this version of SFSE. 
 
-    If the mods has updated for Starfield `v1.14.70` then it should be good, 
+    If the mods has updated for Starfield `v1.14.74` then it should be good, 
     otherwise get in contact with me and I'll add it to the incompatible list below.
 
     **NOTE** 
@@ -18,7 +18,7 @@
 
 #
 
-### Updated as of Starfield `v1.14.70`
+### Updated as of Starfield `v1.14.74`
 
 Incompatible Info:
 

--- a/src/cli/cli.ps1
+++ b/src/cli/cli.ps1
@@ -76,6 +76,21 @@ Do {
                 switch ($moveGameFilesOption) {
                     1 {
                         Clear-Host
+
+                        $choice = getConfigProperty "hardlinkOrCopy"
+                        $newGamePath = getConfigProperty "newGamePath"
+
+                        if (!$choice -and !$newGamePath) {
+                            setFilesChoice
+                            setGamePath
+                        }
+                        elseif (!$choice) {
+                            setFilesChoice
+                        }
+                        elseif (!$newGamePath) {
+                            setGamePath
+                        }
+
                         moveGameFiles
                         break
                     }

--- a/src/cli/cli.ps1
+++ b/src/cli/cli.ps1
@@ -105,7 +105,7 @@ Do {
                 switch ($setConfigOption) {
                     1 {
                         Clear-Host
-                        setGamePaths
+                        setGamePath
                         break
                     }
                     2 {
@@ -133,6 +133,16 @@ Do {
                         refresh
                         break
                     }
+                    7 {
+                        Clear-Host
+                        if (sfseRegistryExists) {
+                            removeSFSERegistry
+                        }
+                        else {
+                            setSFSERegistry
+                        }
+                        break
+                    }
                     Default {
                     }
                 }
@@ -141,6 +151,8 @@ Do {
                 Clear-Host
                 Write-Host "`n`t Config"
                 Write-Host "`t---------"
+                Write-Host "`tRegistry Bypass: $(sfseRegistryExists)"
+                Write-Host "`t"
                 Write-Host "`tGame Path: $(getConfigProperty "gamePath")"
                 Write-Host "`t"
                 Write-Host "`tCopied/Hardlinked Path: $(getConfigProperty "newGamePath" )"
@@ -157,9 +169,10 @@ Do {
                     1. Set Paths
                     2. Set Bypass Choice
                     3. Set Python Choice
-                    4. Set Game File Choice
+                    4. Set Game Transfer Choice
                     5. Uninstall Dependencies (Choco Packages only)
                     6. Refresh Environment (If Choco Packages are not detected)
+                    7. $(if (-Not (sfseRegistryExists)) {"Add Registry Bypass"} else {"Remove Registry Bypass"})
                     q. Return
                 "
                 $setConfigOption = Read-Host "Choose an option"

--- a/src/cli/cli.ps1
+++ b/src/cli/cli.ps1
@@ -166,7 +166,7 @@ Do {
                 Clear-Host
                 Write-Host "`n`t Config"
                 Write-Host "`t---------"
-                Write-Host "`tRegistry Bypass: $(sfseRegistryExists)"
+                Write-Host "`tSFSE Enabled: $(sfseRegistryExists)"
                 Write-Host "`t"
                 Write-Host "`tGame Path: $(getConfigProperty "gamePath")"
                 Write-Host "`t"
@@ -185,9 +185,11 @@ Do {
                     2. Set Bypass Choice
                     3. Set Python Choice
                     4. Set Game Transfer Choice
+                    
                     5. Uninstall Dependencies (Choco Packages only)
                     6. Refresh Environment (If Choco Packages are not detected)
-                    7. $(if (-Not (sfseRegistryExists)) {"Add Registry Bypass"} else {"Remove Registry Bypass"})
+                    
+                    7. $(if (-Not (sfseRegistryExists)) {"Enable SFSE"} else {"Disable SFSE"})
                     q. Return
                 "
                 $setConfigOption = Read-Host "Choose an option"

--- a/src/cli/functions.ps1
+++ b/src/cli/functions.ps1
@@ -702,7 +702,6 @@ function autoInstall() {
     buildRepo
     setSFSERegistry
     moveSFSEFiles
-    moveGameEXE
 
     Clear-Host
     writeToConsole "`n`tYou're ready to start using SFSE mods!"
@@ -805,12 +804,17 @@ function welcomeScreen() {
     $title = (Get-Content -Raw "header.txt").Replace('x.x.x', $version).Replace('[at]', '@')
 
     writeToConsole $title
-    writeToConsole "`n`tIn order to make the auto-install process as smooth as possible we'll set some options now, `n`tThis can be changed from the options menu." -type -color yellow -bgcolor black
+    writeToConsole "`n`tIn order to make the auto-install process as smooth as possible we'll set some options now, `n`tthis can be changed from the options menu." -type -color yellow -bgcolor black
     writeToConsole "`n`tOnce these are set, you won't see this screen again on start-up." -type -color yellow -bgcolor black
 
-    writeToConsole "`n`tCopying the game files is no longer required as of v1.6.0," -type -color yellow -bgcolor black
-    writeToConsole "`tsfse_loader can now be executed directly in the game folder," -type -color yellow -bgcolor black
-    writeToConsole "`tbut the option is still available via the menus." -type -color yellow -bgcolor black
+    writeToConsole "`n`tCopying the game files, executable to bypass permissions is no longer required to launch SFSE as of v1.6.0," -type -color yellow -bgcolor black
+    writeToConsole "`tAs is setting the game install path manually, this will be automatically set for you." -type -color yellow -bgcolor black
+
+    writeToConsole "`n`tSFSE will be enabled by default when using the 'auto' option," -type -color yellow -bgcolor black
+    writeToConsole "`tthis will allow you to launch SFSE via the winstore shortcut directly." -type -color yellow -bgcolor black
+
+    writeToConsole "`n`tYou can enable/disable this option via the options menu, when you want to play vanilla." -type -color green -bgcolor black
+    writeToConsole "`n"
 
     Pause
     setPythonChoice
@@ -831,7 +835,7 @@ if (!(testPath (getConfigPath))) {
 }
 else {
     $gamePathConfig = getConfigProperty "gamePath"
-    $gamePathReg = getStarfieldPath -symlink
+    $gamePathReg = getStarfieldPath
 
     if ($gamePathReg -ne $gamePathConfig) {
         setSFSEPath

--- a/src/cli/functions.ps1
+++ b/src/cli/functions.ps1
@@ -533,13 +533,7 @@ function checkForPStools() {
 
 function moveGameEXE() {
     $gamePath = getConfigProperty "gamePath"
-
-    if (sfseRegistryExists) {
-        $newGamePath = $gamePath | Split-Path
-    }
-    else {
-        $newGamePath = getConfigProperty "newGamePath"
-    }
+    $newGamePath = getConfigProperty "newGamePath"
 
     # Check for permissions before copying exe
     if (!(hasPermissions $newGamePath)) {
@@ -588,11 +582,6 @@ function moveGameEXE() {
             # check exe was copied back to starfield install folder
             if (fileExists -Path $gamePath -FileName 'Starfield.exe') {
                 writeToConsole "`n`tCopy of Starfield.exe created in original folder!" -log
-
-                # Clean up moved exe if using registry
-                if (sfseRegistryExists) {
-                    Remove-Item (Join-Path $newGamePath 'Starfield.exe')
-                }
             }
 
             Start-Sleep -Seconds 5

--- a/src/cli/utils.Tests.ps1
+++ b/src/cli/utils.Tests.ps1
@@ -1,226 +1,227 @@
-BeforeAll {
-    $modulePath = (Join-Path $PSScriptRoot utils.psm1)
-    Import-Module -Name $modulePath
-
-    # Mock default commands
-    Mock -ModuleName utils Test-Path { return $true }
-    Mock -ModuleName utils Join-Path { return '/fake/' }
-    Mock -ModuleName utils Write-Host {}
-    Mock -ModuleName utils Write-Information {}
-
-    Mock -ModuleName utils Get-Date {}
-    Mock -ModuleName utils Out-File {}
-}
-
 Describe "Utils" {
     BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        $modulePath = (Join-Path $PSScriptRoot utils.psm1)
+        Import-Module -Name $modulePath
     }
 
     Describe "testPath" {
 
-        It "should have a testPath function" {
-            $moduleFunctions | Should -Contain 'testPath'
+            BeforeAll {
+                $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+                
+                Mock -ModuleName utils Join-Path { return '/fake/' }
+                Mock -ModuleName utils Test-Path { return $true }
+            }        
+
+            It "should have a testPath function" {
+                $moduleFunctions | Should -Contain 'testPath'
+            }
+
+            Context "parameters" {
+                It "should have a parameter named path" {
+                    Get-Command testPath | Should -HaveParameter path -Type String
+                    Get-Command testPath | Should -HaveParameter path -Mandatory:$false
+                }
+            }
+
+            Context "functionality" {
+                It "should call Test-Path" {
+                    testPath 'path/fake' |
+
+                    Should -Be $true
+                    Should -Invoke Test-Path -ModuleName utils -Times 1
+                }
+            }
+        }
+
+
+
+        Describe "fileExists" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+
+            Mock -ModuleName utils Join-Path { return '/fake/' }
+            Mock -ModuleName utils Test-Path { return $true }
+        }
+
+        It "should have a fileExists function" {
+            $moduleFunctions | Should -Contain 'fileExists'
         }
 
         Context "parameters" {
-            It "should have a parameter named path" {
-                Get-Command testPath | Should -HaveParameter path -Type String
-                Get-Command testPath | Should -HaveParameter path -Mandatory:$false
+            It "should have a mandatory parameter named path" {
+                Get-Command fileExists | Should -HaveParameter path -Type String
+                Get-Command fileExists | Should -HaveParameter path -Mandatory:$true
+            }
+            It "should have an optional parameter named fileName" {
+                Get-Command fileExists | Should -HaveParameter fileName -Type String
+                Get-Command fileExists | Should -HaveParameter fileName -Mandatory:$false
             }
         }
 
         Context "functionality" {
             It "should call Test-Path" {
-                testPath 'path/fake' |
+                fileExists -Path 'path/fake' |
 
                 Should -Be $true
                 Should -Invoke Test-Path -ModuleName utils -Times 1
             }
-        }
-    }
-}
 
-Describe "fileExists" {
-    BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-    }
-
-    It "should have a fileExists function" {
-        $moduleFunctions | Should -Contain 'fileExists'
-    }
-
-    Context "parameters" {
-        It "should have a mandatory parameter named path" {
-            Get-Command fileExists | Should -HaveParameter path -Type String
-            Get-Command fileExists | Should -HaveParameter path -Mandatory:$true
-        }
-        It "should have an optional parameter named fileName" {
-            Get-Command fileExists | Should -HaveParameter fileName -Type String
-            Get-Command fileExists | Should -HaveParameter fileName -Mandatory:$false
+            It "should call Join-Path if fileName provided" {
+                fileExists -Path 'path/fake' -FileName 'test'
+                Should -Invoke Join-Path -ModuleName utils -Times 1
+            }
         }
     }
 
-    Context "functionality" {
-        It "should call Test-Path" {
-            fileExists -Path 'path/fake' |
-
-            Should -Be $true
-            Should -Invoke Test-Path -ModuleName utils -Times 1
+    Describe "writeToConsole" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            Mock -ModuleName utils logToFile -MockWith {}
+            Mock -ModuleName utils Write-Information {}
+            Mock -ModuleName utils Write-Host {}
         }
 
-        It "should call Join-Path if fileName provided" {
-            fileExists -Path 'path/fake' -FileName 'test'
-            Should -Invoke Join-Path -ModuleName utils -Times 1
-        }
-    }
-}
-
-Describe "writeToConsole" {
-    BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-        Mock -ModuleName utils logToFile -MockWith {}
-    }
-
-    It "should have a writeToConsole function" {
-        $moduleFunctions | Should -Contain 'writeToConsole'
-    }
-
-    Context "parameters" {
-        It "should have an optional parameter named msg" {
-            Get-Command writeToConsole | Should -HaveParameter msg -Type String
-            Get-Command writeToConsole | Should -HaveParameter msg -Mandatory:$true
-        }
-        It "should have an optional parameter named type" {
-            Get-Command writeToConsole | Should -HaveParameter type -Type switch
-            Get-Command writeToConsole | Should -HaveParameter type -Mandatory:$false
+        It "should have a writeToConsole function" {
+            $moduleFunctions | Should -Contain 'writeToConsole'
         }
 
-        It "should have an optional parameter named color" {
-            Get-Command writeToConsole | Should -HaveParameter color -Type String
-            Get-Command writeToConsole | Should -HaveParameter color -Mandatory:$false
+        Context "parameters" {
+            It "should have an optional parameter named msg" {
+                Get-Command writeToConsole | Should -HaveParameter msg -Type String
+                Get-Command writeToConsole | Should -HaveParameter msg -Mandatory:$true
+            }
+            It "should have an optional parameter named type" {
+                Get-Command writeToConsole | Should -HaveParameter type -Type switch
+                Get-Command writeToConsole | Should -HaveParameter type -Mandatory:$false
+            }
+
+            It "should have an optional parameter named color" {
+                Get-Command writeToConsole | Should -HaveParameter color -Type String
+                Get-Command writeToConsole | Should -HaveParameter color -Mandatory:$false
+            }
+
+            It "should have an optional parameter named bgcolor" {
+                Get-Command writeToConsole | Should -HaveParameter bgcolor -Type String
+                Get-Command writeToConsole | Should -HaveParameter bgcolor -Mandatory:$false
+            }
+            It "should have an optional parameter named log" {
+                Get-Command writeToConsole | Should -HaveParameter log -Type switch
+                Get-Command writeToConsole | Should -HaveParameter log -Mandatory:$false
+            }
         }
 
-        It "should have an optional parameter named bgcolor" {
-            Get-Command writeToConsole | Should -HaveParameter bgcolor -Type String
-            Get-Command writeToConsole | Should -HaveParameter bgcolor -Mandatory:$false
-        }
-        It "should have an optional parameter named log" {
-            Get-Command writeToConsole | Should -HaveParameter log -Type switch
-            Get-Command writeToConsole | Should -HaveParameter log -Mandatory:$false
-        }
-    }
+        Context "functionality" {
+            It "should call Write-Information when passing only msg" {
+                writeToConsole -msg "test"
+                Should -Invoke Write-Information -ModuleName utils -Times 1
+            }
 
-    Context "functionality" {
-        It "should call Write-Information when passing only msg" {
-            writeToConsole -msg "test"
-            Should -Invoke Write-Information -ModuleName utils -Times 1
-        }
+            It "should call Write-Information & logToFile when passing msg and log param" {
+                #Add global variable for logpath
+                $global:LogPath = '/path/'
 
-        It "should call Write-Information & logToFile when passing msg and log param" {
-            #Add global variable for logpath
-            $global:LogPath = '/path/'
+                writeToConsole -msg "test" -log
+                Should -Invoke Write-Information -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1
 
-            writeToConsole -msg "test" -log
-            Should -Invoke Write-Information -ModuleName utils -Times 1
-            Should -Invoke logToFile -ModuleName utils -Times 1
-
-            # Remove global variable
-            Remove-Variable -Name LogPath -Scope Global
+                # Remove global variable
+                Remove-Variable -Name LogPath -Scope Global
+            }
         }
     }
-}
 
-Describe "getLatestFileName" {
-    BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+    Describe "getLatestFileName" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
 
-        $unsortedArrayOfHexTables =
-        'hex_table_1.7.29_d4e7645.json',
-        'hex_table_1.12.30_dd60417.json',
-        'hex_table_1.9.51_4cde620.json',
-        'hex_table_1.13.61_2f1f1ce.json'
+            $unsortedArrayOfHexTables =
+            'hex_table_1.7.29_d4e7645.json',
+            'hex_table_1.12.30_dd60417.json',
+            'hex_table_1.9.51_4cde620.json',
+            'hex_table_1.13.61_2f1f1ce.json'
 
-        Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith {
-            return $unsortedArrayOfHexTables | ForEach-Object { @{ Name = $_ } }
+            Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith {
+                return $unsortedArrayOfHexTables | ForEach-Object { @{ Name = $_ } }
+            }
+
+            Mock -ModuleName utils -CommandName 'getFullPath' -MockWith {}
         }
 
-        Mock -ModuleName utils -CommandName 'getFullPath' -MockWith {}
-    }
+        It "should have a getLatestFileName function" {
+            $moduleFunctions | Should -Contain 'getLatestFileName'
+        }
 
-    It "should have a getLatestFileName function" {
-        $moduleFunctions | Should -Contain 'getLatestFileName'
-    }
+        Context "functionality" {
+            It "should return the latest file name" {
+                getLatestFileName |
 
-    Context "functionality" {
-        It "should return the latest file name" {
-            getLatestFileName |
-
-            Should -eq 'hex_table_1.13.61_2f1f1ce.json'
-            Should -Invoke Get-ChildItem -ModuleName utils -Times 1
+                Should -eq 'hex_table_1.13.61_2f1f1ce.json'
+                Should -Invoke Get-ChildItem -ModuleName utils -Times 1
+            }
         }
     }
-}
 
-Describe "getLatestCommitId" {
-    BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-        Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
-    }
+    Describe "getLatestCommitId" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
+        }
 
-    It "should have a getLatestCommitId function" {
-        $moduleFunctions | Should -Contain 'getLatestCommitId'
-    }
+        It "should have a getLatestCommitId function" {
+            $moduleFunctions | Should -Contain 'getLatestCommitId'
+        }
 
-    Context "functionality" {
-        It "should return the latest commit id" {
-            getLatestCommitId |
+        Context "functionality" {
+            It "should return the latest commit id" {
+                getLatestCommitId |
 
-            Should -eq '2f1f1ce'
-            Should -Invoke getLatestFileName -ModuleName utils -Times 1
+                Should -eq '2f1f1ce'
+                Should -Invoke getLatestFileName -ModuleName utils -Times 1
+            }
         }
     }
-}
 
-Describe "getGameVersion" {
-    BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-        Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
-    }
+    Describe "getGameVersion" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
+        }
 
-    It "should have a getGameVersion function" {
-        $moduleFunctions | Should -Contain 'getGameVersion'
-    }
+        It "should have a getGameVersion function" {
+            $moduleFunctions | Should -Contain 'getGameVersion'
+        }
 
-    Context "functionality" {
-        It "should return the latest game version and replace the delimiter" {
-            getGameVersion |
+        Context "functionality" {
+            It "should return the latest game version and replace the delimiter" {
+                getGameVersion |
 
-            Should -eq '1_13_61'
-            Should -Invoke getLatestFileName -ModuleName utils -Times 1
+                Should -eq '1_13_61'
+                Should -Invoke getLatestFileName -ModuleName utils -Times 1
+            }
         }
     }
-}
 
-Describe "getConfigProperty" {
-    BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-        $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
+    Describe "getConfigProperty" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
 
-        Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
-    }
-
-    It "should have a getConfigProperty function" {
-        $moduleFunctions | Should -Contain 'getConfigProperty'
-    }
-
-    Context "functionality" {
-        It "should return the property value if present in the config file" {
-            getConfigProperty "gamePath" |
-
-            Should -eq "C:\XboxGames\Starfield\Content"
-            Should -Invoke Get-Content -ModuleName utils -Times 1
+            Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
+            Mock -ModuleName utils Out-File {}
         }
+
+        It "should have a getConfigProperty function" {
+            $moduleFunctions | Should -Contain 'getConfigProperty'
+        }
+
+        Context "functionality" {
+            It "should return the property value if present in the config file" {
+                getConfigProperty "gamePath" |
+
+                Should -eq "C:\XboxGames\Starfield\Content"
+                Should -Invoke Get-Content -ModuleName utils -Times 1
+            }
 
         It "should return $false if the property does not exist" {
             getConfigProperty "debug" |
@@ -229,75 +230,547 @@ Describe "getConfigProperty" {
             Should -Invoke Get-Content -ModuleName utils -Times 1
         }
 
-        It "should write to log if the config file does not exist" {
-            #Add global variable for logpath
-            $global:LogPath = '/path/'
+            It "should write to log if the config file does not exist" {
+                #Add global variable for logpath
+                $global:LogPath = '/path/'
 
-            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
+                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
+                Mock -ModuleName utils -CommandName 'logToFile'
+
+                getConfigProperty "gamePath" |
+
+                Should -BeNullOrEmpty
+                Should -Invoke Get-Content -ModuleName utils -Times 0
+                Should -Invoke fileExists -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1
+
+                # Remove global variable
+                Remove-Variable -Name LogPath -Scope Global
+            }
+        }
+    }
+
+
+    Describe "setConfigProperty" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
+
+            Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
+            Mock -ModuleName utils -CommandName 'ConvertFrom-Json' -MockWith { return @{ "gamePath" = "C:\\XboxGames\\Starfield\\Content" } }
+            Mock -ModuleName utils -CommandName 'ConvertTo-Json' -MockWith { return $configJson }
+            Mock -ModuleName utils -CommandName 'Add-Member'
+
+            Mock -ModuleName utils Out-File {}
+        }
+
+        It "should have a setConfigProperty function" {
+            $moduleFunctions | Should -Contain 'setConfigProperty'
+        }
+
+        Context "functionality" {
+            It "should create a new config file, if it doesn't already exist and store the given prop/val" {
+                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
+
+                setConfigProperty "key" "val" |
+
+                Should -Invoke Get-Content -ModuleName utils -Times 0
+                Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
+                Should -Invoke Out-File -ModuleName utils -Times 1
+            }
+
+            It "should extend the config file if it exists and key/val does not" {
+                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
+
+                setConfigProperty "key" "val" |
+
+                Should -Invoke Get-Content -ModuleName utils -Times 1
+                Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
+                Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
+                Should -Invoke Out-File -ModuleName utils -Times 1
+                Should -Invoke Add-Member -ModuleName utils -Times 1
+            }
+
+            It "should replace the value of the property if it already exists in the config" {
+                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
+
+                setConfigProperty "gamePath" "C:\\XboxGames\\Starfield\\Content" |
+
+                Should -Invoke Get-Content -ModuleName utils -Times 1
+                Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
+                Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
+                Should -Invoke Out-File -ModuleName utils -Times 1
+                Should -Invoke Add-Member -ModuleName utils -Times 0
+            }
+        }
+    }
+
+    Describe "findRegistryKeys" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            $objArr = 'testKey1', 'testKey2'
+
+            Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith { return $objArr }
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+        }
+
+        It "should have a findRegistryKeys function" {
+            $moduleFunctions | Should -Contain 'findRegistryKeys'
+        }
+
+        Context "parameters" {
+            It "should have a parameter named path" {
+                Get-Command findRegistryKeys | Should -HaveParameter path -Type String
+                Get-Command findRegistryKeys | Should -HaveParameter path -Mandatory:$false
+            }
+        }
+
+        Context "functionality" {
+            It "should return the keys if they exist" {
+                findRegistryKeys "fake\registry\path" |
+
+                Should -eq 'testKey1', 'testKey2'
+                Should -Invoke Get-ChildItem -ModuleName utils -Times 1
+            }
+
+            It "should return $false if there are no keys in path" {
+                Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith { return $False }
+                
+                findRegistryKeys "fake\registry\path" |
+
+                Should -BeFalse
+                Should -Invoke Get-ChildItem -ModuleName utils -Times 1
+            }
+
+            It "should write to log if the path does not exist" {
+                #Add global variable for logpath
+                $global:LogPath = '/path/'
+
+                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+                Mock -ModuleName utils -CommandName 'logToFile'
+
+                findRegistryKeys "fake\registry\path" |
+
+                Should -BeFalse
+                Should -Invoke Get-ChildItem -ModuleName utils -Times 0
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1
+
+                # Remove global variable
+                Remove-Variable -name LogPath -Scope Global
+            }
+        }
+    }
+
+    Describe "findRegistryValues" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            $obj = [PSCustomObject]@{
+                key1 = "value1";
+                key2 = "value2";
+            }
+
+            Mock -ModuleName utils -CommandName 'Get-ItemProperty' -MockWith { return $obj }
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+        }
+
+        It "should have a findRegistryValues function" {
+            $moduleFunctions | Should -Contain 'findRegistryValues'
+        }
+
+        Context "parameters" {
+            It "should have a mandatory parameter named path" {
+                Get-Command findRegistryValues | Should -HaveParameter path -Type String
+                Get-Command findRegistryValues | Should -HaveParameter path -Mandatory:$true
+            }
+            It "should have an optional parameter named value" {
+                Get-Command findRegistryValues | Should -HaveParameter value -Type String
+                Get-Command findRegistryValues | Should -HaveParameter value -Mandatory:$false
+            }
+        }
+
+        Context "functionality" {
+            It "should return all values of reg key" {
+                $expected = @{key1 = 'value1'; key2 = 'value2' }
+                $result = findRegistryValues "fake\registry\path"
+
+                Assert-Equivalent -Actual $result -Expected $expected
+                Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+            }
+
+            It "should return values matching the wildcard" {
+                $expected = @{key2 = 'value2' }
+                $result = findRegistryValues "fake\registry\path" "key2"
+                
+                Assert-Equivalent -Actual $result -Expected $expected
+                Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+            }
+
+            It "should return $false if there are no values" {
+                Mock -ModuleName utils -CommandName 'Get-ItemProperty' -MockWith { return $False }
+                
+                findRegistryValues "fake\registry\path" |
+
+                Should -BeFalse
+                Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
+            }
+
+            It "should write to log if the path does not exist" {
+                #Add global variable for logpath
+                $global:LogPath = '/path/'
+
+                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+                Mock -ModuleName utils -CommandName 'logToFile'
+
+                findRegistryValues "fake\registry\path" |
+
+                Should -BeFalse
+                Should -Invoke Get-ItemProperty -ModuleName utils -Times 0
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1
+
+                # Remove global variable
+                Remove-Variable -name LogPath -Scope Global
+            }
+        }
+    }
+
+    Describe "getStarfieldPackage" {
+        BeforeAll {
+            #Add global variable for logpath
+            $global:pkgRegPath = 'fake/reg/path'
+            $global:LogPath = '/path/'
+                
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            $obj = [hashtable]@{
+                key1 = "value1";
+            }
+
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+            Mock -ModuleName utils -CommandName 'logToFile'
+        }
+
+        AfterAll {
+            # Remove global variable
+            Remove-Variable -Name pkgRegPath -Scope Global
+            Remove-Variable -Name LogPath -Scope Global
+        }
+
+        It "should have a getStarfieldPackage function" {
+            $moduleFunctions | Should -Contain 'getStarfieldPackage'
+        }
+
+        Context "parameters" {
+            It "should have an optional parameter named key" {
+                Get-Command getStarfieldPackage | Should -HaveParameter key -Type switch
+                Get-Command getStarfieldPackage | Should -HaveParameter key -Mandatory:$false
+            }
+        }
+
+        Context "functionality" {
+            It "should return only the key if 'key' boolean is passed" {
+                getStarfieldPackage -key |
+                
+                Should -Be "key1"
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+            }
+
+            It "should return only the value if 'key' boolean not passed" {
+                getStarfieldPackage |
+                
+                Should -Be "value1"
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+            }
+
+            It "should return $false if the package doesn't exist" {
+                Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
+                
+                getStarfieldPackage |
+
+                Should -BeFalse
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1
+            }
+
+            It "should write to log if the path does not exist" {
+                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+                Mock -ModuleName utils -CommandName 'logToFile'
+
+                getStarfieldPackage |
+
+                Should -BeFalse
+                Should -Invoke findRegistryValues -ModuleName utils -Times 0
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1
+            }
+        }
+    }
+
+    Describe "getStarfieldPath" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            
+            $obj = [hashtable]@{
+                key1 = "\\?\value1";
+            }
+
+            $symObj = [PSCustomObject]@{Target = 'symlink/path' };
+
+            Mock -ModuleName utils -CommandName 'getStarfieldPackage' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'findRegistryKeys' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+            
+            Mock -ModuleName utils Get-Item -MockWith { return $symObj }
+            Mock -ModuleName utils Split-Path -ParameterFilter { $Path -eq $symObj.Target } -MockWith { return $symObj.Target | Split-Path }
+        }
+
+        It "should have a getStarfieldPath function" {
+            $moduleFunctions | Should -Contain 'getStarfieldPath'
+        }
+
+        Context "parameters" {
+            It "should have an optional parameter named symlink" {
+                Get-Command getStarfieldPath | Should -HaveParameter symlink -Type switch
+                Get-Command getStarfieldPath | Should -HaveParameter symlink -Mandatory:$false
+            }
+        }
+
+        Context "functionality" {
+            It "should return the path with the prefix removed" {
+                getStarfieldPath |
+
+                Should -Be 'value1'
+                Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
+                Should -Invoke findRegistryKeys -ModuleName utils -Times 1
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            }
+
+            It "should return the symlink path when pass symlink parameter" {
+                getStarfieldPath -symlink |
+
+                Should -Be 'symlink'
+                Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
+                Should -Invoke findRegistryKeys -ModuleName utils -Times 1
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            }
+
+            It "should return $false the path doesn't exist" {
+                Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
+                
+                getStarfieldPath |
+
+                Should -BeFalse
+                Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
+                Should -Invoke findRegistryKeys -ModuleName utils -Times 1
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            }
+        }
+    }
+
+    Describe "getRegConfigPath" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+
+            Mock -ModuleName utils -CommandName 'getStarfieldPackage' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'Join-Path' -MockWith { return 'Path' }
+            Mock -ModuleName utils -CommandName 'logToFile'
+        }
+
+        It "should have a getRegConfigPath function" {
+            $moduleFunctions | Should -Contain 'getRegConfigPath'
+        }
+
+        Context "functionality" {
+            It "should return the path if exist" {
+                getRegConfigPath |
+
+                Should -Be 'Path'
+                Should -Invoke logToFile -ModuleName utils -Times 0
+            }
+
+            It "should return $false and write to log if it does NOT exist" {
+                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+
+                getRegConfigPath |
+
+                Should -BeFalse
+                Should -Invoke logToFile -ModuleName utils -Times 1
+            }
+        }
+    }
+
+    Describe "sfseRegistryExists" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+
+            Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'logToFile'
+        }
+
+        It "should have a sfseRegistryExists function" {
+            $moduleFunctions | Should -Contain 'sfseRegistryExists'
+        }
+
+        Context "functionality" {
+            It "should return $true if exist" {
+                sfseRegistryExists |
+
+                Should -BeTrue
+                Should -Invoke logToFile -ModuleName utils -Times 0
+                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+            }
+
+            It "should return $false and write to log if it does NOT exist" {
+                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+
+                sfseRegistryExists |
+
+                Should -BeFalse
+                Should -Invoke logToFile -ModuleName utils -Times 1
+                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+            }
+        }
+    }
+
+    Describe "backupGameReg" {
+        BeforeAll {
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            
+            $obj = [hashtable]@{
+                Version = "0.1.70.0";
+            }
+
+            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $True }
+            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
             Mock -ModuleName utils -CommandName 'logToFile'
 
-            getConfigProperty "gamePath" |
+            Mock -ModuleName utils -CommandName 'New-Item'
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+            Mock -ModuleName utils -CommandName 'reg'
+        }
 
-            Should -BeNullOrEmpty
-            Should -Invoke Get-Content -ModuleName utils -Times 0
-            Should -Invoke fileExists -ModuleName utils -Times 1
-            Should -Invoke logToFile -ModuleName utils -Times 1
+        It "should have a backupGameReg function" {
+            $moduleFunctions | Should -Contain 'backupGameReg'
+        }
 
+        Context "functionality" {
+            It "should call reg export" {
+                backupGameReg
+
+                Should -Invoke fileExists -ModuleName utils -Times 1
+                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+                Should -Invoke reg -ModuleName utils -Times 1
+            }
+
+            It "should NOT call reg export if file exists" {
+                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+
+                backupGameReg
+
+                Should -Invoke fileExists -ModuleName utils -Times 1
+                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+                Should -Invoke findRegistryValues -ModuleName utils -Times 1
+                Should -Invoke Test-Path -ModuleName utils -Times 1
+                Should -Invoke reg -ModuleName utils -Times 0
+                Should -Invoke logToFile -ModuleName utils -Times 1
+            }
+
+            It "should create the folder if it doesn't exist" {
+                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
+                
+                backupGameReg
+                Should -Invoke New-Item -ModuleName utils -Times 1
+            }
+            
+            It "should write to log if the game version is not found" {
+                Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
+
+                backupGameReg
+                Should -Invoke logToFile -ModuleName utils -Times 1
+            }
+        }
+    }
+
+    Describe "setSFSERegistry" {
+        BeforeAll {
+            $global:LogPath = '/path/'
+
+            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+            $regConfigPath = 'path/to/reg'
+
+            Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $regConfigPath }
+            Mock -ModuleName utils -CommandName 'sfseRegistryExists' -MockWith { return $False }
+            Mock -ModuleName utils -CommandName 'backupGameReg'
+            Mock -ModuleName utils -CommandName 'logToFile'
+            
+            Mock -ModuleName utils -CommandName 'Copy-Item'
+            Mock -ModuleName utils -CommandName 'Set-ItemProperty'
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+        }
+
+        AfterAll {
             # Remove global variable
             Remove-Variable -Name LogPath -Scope Global
         }
-    }
-}
 
-
-Describe "setConfigProperty" {
-    BeforeAll {
-        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-        $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
-
-        Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
-        Mock -ModuleName utils -CommandName 'ConvertFrom-Json' -MockWith { return @{ "gamePath" = "C:\\XboxGames\\Starfield\\Content" } }
-        Mock -ModuleName utils -CommandName 'ConvertTo-Json' -MockWith { return $configJson }
-        Mock -ModuleName utils -CommandName 'Add-Member'
-    }
-
-    It "should have a setConfigProperty function" {
-        $moduleFunctions | Should -Contain 'setConfigProperty'
-    }
-
-    Context "functionality" {
-        It "should create a new config file, if it doesn't already exist and store the given prop/val" {
-            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
-
-            setConfigProperty "key" "val" |
-
-            Should -Invoke Get-Content -ModuleName utils -Times 0
-            Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
-            Should -Invoke Out-File -ModuleName utils -Times 1
+        It "should have a setSFSERegistry function" {
+            $moduleFunctions | Should -Contain 'setSFSERegistry'
         }
 
-        It "should extend the config file if it exists and key/val does not" {
-            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
+        Context "functionality" {
+            It "should copy and update the registry" {
+                setSFSERegistry
 
-            setConfigProperty "key" "val" |
+                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+                Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
+                Should -Invoke backupGameReg -ModuleName utils -Times 1
+                Should -Invoke Test-Path -ModuleName utils -Times 2
 
-            Should -Invoke Get-Content -ModuleName utils -Times 1
-            Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
-            Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
-            Should -Invoke Out-File -ModuleName utils -Times 1
-            Should -Invoke Add-Member -ModuleName utils -Times 1
-        }
+                Should -Invoke Copy-Item -ModuleName utils -Times 1
+                Should -Invoke Set-ItemProperty -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1 
+            }
 
-        It "should replace the value of the property if it already exists in the config" {
-            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
+            It "should NOT copy and update the registry, if custom registry entry exists" {
+                Mock -ModuleName utils -CommandName 'sfseRegistryExists' -MockWith { return $True }
+                
+                setSFSERegistry
 
-            setConfigProperty "gamePath" "C:\\XboxGames\\Starfield\\Content" |
+                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+                Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1 
 
-            Should -Invoke Get-Content -ModuleName utils -Times 1
-            Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
-            Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
-            Should -Invoke Out-File -ModuleName utils -Times 1
-            Should -Invoke Add-Member -ModuleName utils -Times 0
+                Should -Invoke backupGameReg -ModuleName utils -Times 0
+                Should -Invoke Test-Path -ModuleName utils -Times 0
+                Should -Invoke Copy-Item -ModuleName utils -Times 0
+                Should -Invoke Set-ItemProperty -ModuleName utils -Times 0
+            }
+
+            It "should NOT copy and update the registry, if config path doesn't exist" {
+                Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $False }
+                
+                setSFSERegistry
+
+                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+                Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
+                Should -Invoke logToFile -ModuleName utils -Times 1 
+
+                Should -Invoke backupGameReg -ModuleName utils -Times 0
+                Should -Invoke Test-Path -ModuleName utils -Times 0
+                Should -Invoke Copy-Item -ModuleName utils -Times 0
+                Should -Invoke Set-ItemProperty -ModuleName utils -Times 0
+            }
         }
     }
 }

--- a/src/cli/utils.Tests.ps1
+++ b/src/cli/utils.Tests.ps1
@@ -1,227 +1,223 @@
-Describe "Utils" {
+BeforeAll {
+    $modulePath = (Join-Path $PSScriptRoot utils.psm1)
+    Import-Module -Name $modulePath
+
+    # Mock default commands
+    Mock -ModuleName utils Test-Path { return $true }
+    Mock -ModuleName utils Join-Path { return '/fake/' }
+    Mock -ModuleName utils Write-Host {}
+    Mock -ModuleName utils Write-Information {}
+
+    Mock -ModuleName utils Get-Date {}
+    Mock -ModuleName utils Out-File {}
+}
+
+Describe "testPath" {
     BeforeAll {
-        $modulePath = (Join-Path $PSScriptRoot utils.psm1)
-        Import-Module -Name $modulePath
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
     }
 
-    Describe "testPath" {
+    It "should have a testPath function" {
+        $moduleFunctions | Should -Contain 'testPath'
+    }
 
-            BeforeAll {
-                $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-                
-                Mock -ModuleName utils Join-Path { return '/fake/' }
-                Mock -ModuleName utils Test-Path { return $true }
-            }        
-
-            It "should have a testPath function" {
-                $moduleFunctions | Should -Contain 'testPath'
-            }
-
-            Context "parameters" {
-                It "should have a parameter named path" {
-                    Get-Command testPath | Should -HaveParameter path -Type String
-                    Get-Command testPath | Should -HaveParameter path -Mandatory:$false
-                }
-            }
-
-            Context "functionality" {
-                It "should call Test-Path" {
-                    testPath 'path/fake' |
-
-                    Should -Be $true
-                    Should -Invoke Test-Path -ModuleName utils -Times 1
-                }
-            }
-        }
-
-
-
-        Describe "fileExists" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-
-            Mock -ModuleName utils Join-Path { return '/fake/' }
-            Mock -ModuleName utils Test-Path { return $true }
-        }
-
-        It "should have a fileExists function" {
-            $moduleFunctions | Should -Contain 'fileExists'
-        }
-
-        Context "parameters" {
-            It "should have a mandatory parameter named path" {
-                Get-Command fileExists | Should -HaveParameter path -Type String
-                Get-Command fileExists | Should -HaveParameter path -Mandatory:$true
-            }
-            It "should have an optional parameter named fileName" {
-                Get-Command fileExists | Should -HaveParameter fileName -Type String
-                Get-Command fileExists | Should -HaveParameter fileName -Mandatory:$false
-            }
-        }
-
-        Context "functionality" {
-            It "should call Test-Path" {
-                fileExists -Path 'path/fake' |
-
-                Should -Be $true
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-            }
-
-            It "should call Join-Path if fileName provided" {
-                fileExists -Path 'path/fake' -FileName 'test'
-                Should -Invoke Join-Path -ModuleName utils -Times 1
-            }
+    Context "parameters" {
+        It "should have a parameter named path" {
+            Get-Command testPath | Should -HaveParameter path -Type String
+            Get-Command testPath | Should -HaveParameter path -Mandatory:$false
         }
     }
 
-    Describe "writeToConsole" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            Mock -ModuleName utils logToFile -MockWith {}
-            Mock -ModuleName utils Write-Information {}
-            Mock -ModuleName utils Write-Host {}
+    Context "functionality" {
+        It "should call Test-Path" {
+            testPath 'path/fake' |
+
+            Should -Be $true
+            Should -Invoke Test-Path -ModuleName utils -Times 1
         }
+    }
+}
 
-        It "should have a writeToConsole function" {
-            $moduleFunctions | Should -Contain 'writeToConsole'
+Describe "fileExists" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+    }
+
+    It "should have a fileExists function" {
+        $moduleFunctions | Should -Contain 'fileExists'
+    }
+
+    Context "parameters" {
+        It "should have a mandatory parameter named path" {
+            Get-Command fileExists | Should -HaveParameter path -Type String
+            Get-Command fileExists | Should -HaveParameter path -Mandatory:$true
         }
-
-        Context "parameters" {
-            It "should have an optional parameter named msg" {
-                Get-Command writeToConsole | Should -HaveParameter msg -Type String
-                Get-Command writeToConsole | Should -HaveParameter msg -Mandatory:$true
-            }
-            It "should have an optional parameter named type" {
-                Get-Command writeToConsole | Should -HaveParameter type -Type switch
-                Get-Command writeToConsole | Should -HaveParameter type -Mandatory:$false
-            }
-
-            It "should have an optional parameter named color" {
-                Get-Command writeToConsole | Should -HaveParameter color -Type String
-                Get-Command writeToConsole | Should -HaveParameter color -Mandatory:$false
-            }
-
-            It "should have an optional parameter named bgcolor" {
-                Get-Command writeToConsole | Should -HaveParameter bgcolor -Type String
-                Get-Command writeToConsole | Should -HaveParameter bgcolor -Mandatory:$false
-            }
-            It "should have an optional parameter named log" {
-                Get-Command writeToConsole | Should -HaveParameter log -Type switch
-                Get-Command writeToConsole | Should -HaveParameter log -Mandatory:$false
-            }
-        }
-
-        Context "functionality" {
-            It "should call Write-Information when passing only msg" {
-                writeToConsole -msg "test"
-                Should -Invoke Write-Information -ModuleName utils -Times 1
-            }
-
-            It "should call Write-Information & logToFile when passing msg and log param" {
-                #Add global variable for logpath
-                $global:LogPath = '/path/'
-
-                writeToConsole -msg "test" -log
-                Should -Invoke Write-Information -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1
-
-                # Remove global variable
-                Remove-Variable -Name LogPath -Scope Global
-            }
+        It "should have an optional parameter named fileName" {
+            Get-Command fileExists | Should -HaveParameter fileName -Type String
+            Get-Command fileExists | Should -HaveParameter fileName -Mandatory:$false
         }
     }
 
-    Describe "getLatestFileName" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+    Context "functionality" {
+        It "should call Test-Path" {
+            fileExists -Path 'path/fake' |
 
-            $unsortedArrayOfHexTables =
-            'hex_table_1.7.29_d4e7645.json',
-            'hex_table_1.12.30_dd60417.json',
-            'hex_table_1.9.51_4cde620.json',
-            'hex_table_1.13.61_2f1f1ce.json'
-
-            Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith {
-                return $unsortedArrayOfHexTables | ForEach-Object { @{ Name = $_ } }
-            }
-
-            Mock -ModuleName utils -CommandName 'getFullPath' -MockWith {}
+            Should -Be $true
+            Should -Invoke Test-Path -ModuleName utils -Times 1
         }
 
-        It "should have a getLatestFileName function" {
-            $moduleFunctions | Should -Contain 'getLatestFileName'
+        It "should call Join-Path if fileName provided" {
+            fileExists -Path 'path/fake' -FileName 'test'
+            Should -Invoke Join-Path -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "writeToConsole" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        Mock -ModuleName utils logToFile -MockWith {}
+    }
+
+    It "should have a writeToConsole function" {
+        $moduleFunctions | Should -Contain 'writeToConsole'
+    }
+
+    Context "parameters" {
+        It "should have an optional parameter named msg" {
+            Get-Command writeToConsole | Should -HaveParameter msg -Type String
+            Get-Command writeToConsole | Should -HaveParameter msg -Mandatory:$true
+        }
+        It "should have an optional parameter named type" {
+            Get-Command writeToConsole | Should -HaveParameter type -Type switch
+            Get-Command writeToConsole | Should -HaveParameter type -Mandatory:$false
         }
 
-        Context "functionality" {
-            It "should return the latest file name" {
-                getLatestFileName |
+        It "should have an optional parameter named color" {
+            Get-Command writeToConsole | Should -HaveParameter color -Type String
+            Get-Command writeToConsole | Should -HaveParameter color -Mandatory:$false
+        }
 
-                Should -eq 'hex_table_1.13.61_2f1f1ce.json'
-                Should -Invoke Get-ChildItem -ModuleName utils -Times 1
-            }
+        It "should have an optional parameter named bgcolor" {
+            Get-Command writeToConsole | Should -HaveParameter bgcolor -Type String
+            Get-Command writeToConsole | Should -HaveParameter bgcolor -Mandatory:$false
+        }
+        It "should have an optional parameter named log" {
+            Get-Command writeToConsole | Should -HaveParameter log -Type switch
+            Get-Command writeToConsole | Should -HaveParameter log -Mandatory:$false
         }
     }
 
-    Describe "getLatestCommitId" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
+    Context "functionality" {
+        It "should call Write-Information when passing only msg" {
+            writeToConsole -msg "test"
+            Should -Invoke Write-Information -ModuleName utils -Times 1
         }
 
-        It "should have a getLatestCommitId function" {
-            $moduleFunctions | Should -Contain 'getLatestCommitId'
-        }
+        It "should call Write-Information & logToFile when passing msg and log param" {
+            #Add global variable for logpath
+            $global:LogPath = '/path/'
 
-        Context "functionality" {
-            It "should return the latest commit id" {
-                getLatestCommitId |
+            writeToConsole -msg "test" -log
+            Should -Invoke Write-Information -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1
 
-                Should -eq '2f1f1ce'
-                Should -Invoke getLatestFileName -ModuleName utils -Times 1
-            }
-        }
-    }
-
-    Describe "getGameVersion" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
-        }
-
-        It "should have a getGameVersion function" {
-            $moduleFunctions | Should -Contain 'getGameVersion'
-        }
-
-        Context "functionality" {
-            It "should return the latest game version and replace the delimiter" {
-                getGameVersion |
-
-                Should -eq '1_13_61'
-                Should -Invoke getLatestFileName -ModuleName utils -Times 1
-            }
+            # Remove global variable
+            Remove-Variable -Name LogPath -Scope Global
         }
     }
+}
 
-    Describe "getConfigProperty" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
+Describe "getLatestFileName" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
 
-            Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
-            Mock -ModuleName utils Out-File {}
+        $unsortedArrayOfHexTables =
+        'hex_table_1.7.29_d4e7645.json',
+        'hex_table_1.12.30_dd60417.json',
+        'hex_table_1.9.51_4cde620.json',
+        'hex_table_1.13.61_2f1f1ce.json'
+
+        Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith {
+            return $unsortedArrayOfHexTables | ForEach-Object { @{ Name = $_ } }
         }
 
-        It "should have a getConfigProperty function" {
-            $moduleFunctions | Should -Contain 'getConfigProperty'
+        Mock -ModuleName utils -CommandName 'getFullPath' -MockWith {}
+    }
+
+    It "should have a getLatestFileName function" {
+        $moduleFunctions | Should -Contain 'getLatestFileName'
+    }
+
+    Context "functionality" {
+        It "should return the latest file name" {
+            getLatestFileName |
+
+            Should -eq 'hex_table_1.13.61_2f1f1ce.json'
+            Should -Invoke Get-ChildItem -ModuleName utils -Times 1
         }
+    }
+}
 
-        Context "functionality" {
-            It "should return the property value if present in the config file" {
-                getConfigProperty "gamePath" |
+Describe "getLatestCommitId" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
+    }
 
-                Should -eq "C:\XboxGames\Starfield\Content"
-                Should -Invoke Get-Content -ModuleName utils -Times 1
-            }
+    It "should have a getLatestCommitId function" {
+        $moduleFunctions | Should -Contain 'getLatestCommitId'
+    }
+
+    Context "functionality" {
+        It "should return the latest commit id" {
+            getLatestCommitId |
+
+            Should -eq '2f1f1ce'
+            Should -Invoke getLatestFileName -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "getGameVersion" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        Mock -ModuleName utils -CommandName 'getLatestFileName' -MockWith { return 'hex_table_1.13.61_2f1f1ce.json' }
+    }
+
+    It "should have a getGameVersion function" {
+        $moduleFunctions | Should -Contain 'getGameVersion'
+    }
+
+    Context "functionality" {
+        It "should return the latest game version and replace the delimiter" {
+            getGameVersion |
+
+            Should -eq '1_13_61'
+            Should -Invoke getLatestFileName -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "getConfigProperty" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
+
+        Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
+    }
+
+    It "should have a getConfigProperty function" {
+        $moduleFunctions | Should -Contain 'getConfigProperty'
+    }
+
+    Context "functionality" {
+        It "should return the property value if present in the config file" {
+            getConfigProperty "gamePath" |
+
+            Should -eq "C:\XboxGames\Starfield\Content"
+            Should -Invoke Get-Content -ModuleName utils -Times 1
+        }
 
         It "should return $false if the property does not exist" {
             getConfigProperty "debug" |
@@ -230,547 +226,544 @@ Describe "Utils" {
             Should -Invoke Get-Content -ModuleName utils -Times 1
         }
 
-            It "should write to log if the config file does not exist" {
-                #Add global variable for logpath
-                $global:LogPath = '/path/'
-
-                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
-                Mock -ModuleName utils -CommandName 'logToFile'
-
-                getConfigProperty "gamePath" |
-
-                Should -BeNullOrEmpty
-                Should -Invoke Get-Content -ModuleName utils -Times 0
-                Should -Invoke fileExists -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1
-
-                # Remove global variable
-                Remove-Variable -Name LogPath -Scope Global
-            }
-        }
-    }
-
-
-    Describe "setConfigProperty" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
-
-            Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
-            Mock -ModuleName utils -CommandName 'ConvertFrom-Json' -MockWith { return @{ "gamePath" = "C:\\XboxGames\\Starfield\\Content" } }
-            Mock -ModuleName utils -CommandName 'ConvertTo-Json' -MockWith { return $configJson }
-            Mock -ModuleName utils -CommandName 'Add-Member'
-
-            Mock -ModuleName utils Out-File {}
-        }
-
-        It "should have a setConfigProperty function" {
-            $moduleFunctions | Should -Contain 'setConfigProperty'
-        }
-
-        Context "functionality" {
-            It "should create a new config file, if it doesn't already exist and store the given prop/val" {
-                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
-
-                setConfigProperty "key" "val" |
-
-                Should -Invoke Get-Content -ModuleName utils -Times 0
-                Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
-                Should -Invoke Out-File -ModuleName utils -Times 1
-            }
-
-            It "should extend the config file if it exists and key/val does not" {
-                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
-
-                setConfigProperty "key" "val" |
-
-                Should -Invoke Get-Content -ModuleName utils -Times 1
-                Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
-                Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
-                Should -Invoke Out-File -ModuleName utils -Times 1
-                Should -Invoke Add-Member -ModuleName utils -Times 1
-            }
-
-            It "should replace the value of the property if it already exists in the config" {
-                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
-
-                setConfigProperty "gamePath" "C:\\XboxGames\\Starfield\\Content" |
-
-                Should -Invoke Get-Content -ModuleName utils -Times 1
-                Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
-                Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
-                Should -Invoke Out-File -ModuleName utils -Times 1
-                Should -Invoke Add-Member -ModuleName utils -Times 0
-            }
-        }
-    }
-
-    Describe "findRegistryKeys" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            $objArr = 'testKey1', 'testKey2'
-
-            Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith { return $objArr }
-            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
-        }
-
-        It "should have a findRegistryKeys function" {
-            $moduleFunctions | Should -Contain 'findRegistryKeys'
-        }
-
-        Context "parameters" {
-            It "should have a parameter named path" {
-                Get-Command findRegistryKeys | Should -HaveParameter path -Type String
-                Get-Command findRegistryKeys | Should -HaveParameter path -Mandatory:$false
-            }
-        }
-
-        Context "functionality" {
-            It "should return the keys if they exist" {
-                findRegistryKeys "fake\registry\path" |
-
-                Should -eq 'testKey1', 'testKey2'
-                Should -Invoke Get-ChildItem -ModuleName utils -Times 1
-            }
-
-            It "should return $false if there are no keys in path" {
-                Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith { return $False }
-                
-                findRegistryKeys "fake\registry\path" |
-
-                Should -BeFalse
-                Should -Invoke Get-ChildItem -ModuleName utils -Times 1
-            }
-
-            It "should write to log if the path does not exist" {
-                #Add global variable for logpath
-                $global:LogPath = '/path/'
-
-                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
-                Mock -ModuleName utils -CommandName 'logToFile'
-
-                findRegistryKeys "fake\registry\path" |
-
-                Should -BeFalse
-                Should -Invoke Get-ChildItem -ModuleName utils -Times 0
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1
-
-                # Remove global variable
-                Remove-Variable -name LogPath -Scope Global
-            }
-        }
-    }
-
-    Describe "findRegistryValues" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            $obj = [PSCustomObject]@{
-                key1 = "value1";
-                key2 = "value2";
-            }
-
-            Mock -ModuleName utils -CommandName 'Get-ItemProperty' -MockWith { return $obj }
-            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
-        }
-
-        It "should have a findRegistryValues function" {
-            $moduleFunctions | Should -Contain 'findRegistryValues'
-        }
-
-        Context "parameters" {
-            It "should have a mandatory parameter named path" {
-                Get-Command findRegistryValues | Should -HaveParameter path -Type String
-                Get-Command findRegistryValues | Should -HaveParameter path -Mandatory:$true
-            }
-            It "should have an optional parameter named value" {
-                Get-Command findRegistryValues | Should -HaveParameter value -Type String
-                Get-Command findRegistryValues | Should -HaveParameter value -Mandatory:$false
-            }
-        }
-
-        Context "functionality" {
-            It "should return all values of reg key" {
-                $expected = @{key1 = 'value1'; key2 = 'value2' }
-                $result = findRegistryValues "fake\registry\path"
-
-                Assert-Equivalent -Actual $result -Expected $expected
-                Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-            }
-
-            It "should return values matching the wildcard" {
-                $expected = @{key2 = 'value2' }
-                $result = findRegistryValues "fake\registry\path" "key2"
-                
-                Assert-Equivalent -Actual $result -Expected $expected
-                Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-            }
-
-            It "should return $false if there are no values" {
-                Mock -ModuleName utils -CommandName 'Get-ItemProperty' -MockWith { return $False }
-                
-                findRegistryValues "fake\registry\path" |
-
-                Should -BeFalse
-                Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
-            }
-
-            It "should write to log if the path does not exist" {
-                #Add global variable for logpath
-                $global:LogPath = '/path/'
-
-                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
-                Mock -ModuleName utils -CommandName 'logToFile'
-
-                findRegistryValues "fake\registry\path" |
-
-                Should -BeFalse
-                Should -Invoke Get-ItemProperty -ModuleName utils -Times 0
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1
-
-                # Remove global variable
-                Remove-Variable -name LogPath -Scope Global
-            }
-        }
-    }
-
-    Describe "getStarfieldPackage" {
-        BeforeAll {
+        It "should write to log if the config file does not exist" {
             #Add global variable for logpath
-            $global:pkgRegPath = 'fake/reg/path'
             $global:LogPath = '/path/'
-                
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            $obj = [hashtable]@{
-                key1 = "value1";
-            }
 
-            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
             Mock -ModuleName utils -CommandName 'logToFile'
-        }
 
-        AfterAll {
+            getConfigProperty "gamePath" |
+
+            Should -BeNullOrEmpty
+            Should -Invoke Get-Content -ModuleName utils -Times 0
+            Should -Invoke fileExists -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1
+
             # Remove global variable
-            Remove-Variable -Name pkgRegPath -Scope Global
             Remove-Variable -Name LogPath -Scope Global
         }
+    }
+}
 
-        It "should have a getStarfieldPackage function" {
-            $moduleFunctions | Should -Contain 'getStarfieldPackage'
-        }
 
-        Context "parameters" {
-            It "should have an optional parameter named key" {
-                Get-Command getStarfieldPackage | Should -HaveParameter key -Type switch
-                Get-Command getStarfieldPackage | Should -HaveParameter key -Mandatory:$false
-            }
-        }
+Describe "setConfigProperty" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        $configJson = '{ "gamePath":  "C:\\XboxGames\\Starfield\\Content" }'
 
-        Context "functionality" {
-            It "should return only the key if 'key' boolean is passed" {
-                getStarfieldPackage -key |
-                
-                Should -Be "key1"
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-            }
-
-            It "should return only the value if 'key' boolean not passed" {
-                getStarfieldPackage |
-                
-                Should -Be "value1"
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-            }
-
-            It "should return $false if the package doesn't exist" {
-                Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
-                
-                getStarfieldPackage |
-
-                Should -BeFalse
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1
-            }
-
-            It "should write to log if the path does not exist" {
-                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
-                Mock -ModuleName utils -CommandName 'logToFile'
-
-                getStarfieldPackage |
-
-                Should -BeFalse
-                Should -Invoke findRegistryValues -ModuleName utils -Times 0
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1
-            }
-        }
+        Mock -ModuleName utils -CommandName 'Get-Content' -MockWith { return $configJson }
+        Mock -ModuleName utils -CommandName 'ConvertFrom-Json' -MockWith { return @{ "gamePath" = "C:\\XboxGames\\Starfield\\Content" } }
+        Mock -ModuleName utils -CommandName 'ConvertTo-Json' -MockWith { return $configJson }
+        Mock -ModuleName utils -CommandName 'Add-Member'
     }
 
-    Describe "getStarfieldPath" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            
-            $obj = [hashtable]@{
-                key1 = "\\?\value1";
-            }
-
-            $symObj = [PSCustomObject]@{Target = 'symlink/path' };
-
-            Mock -ModuleName utils -CommandName 'getStarfieldPackage' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'findRegistryKeys' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
-            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
-            
-            Mock -ModuleName utils Get-Item -MockWith { return $symObj }
-            Mock -ModuleName utils Split-Path -ParameterFilter { $Path -eq $symObj.Target } -MockWith { return $symObj.Target | Split-Path }
-        }
-
-        It "should have a getStarfieldPath function" {
-            $moduleFunctions | Should -Contain 'getStarfieldPath'
-        }
-
-        Context "parameters" {
-            It "should have an optional parameter named symlink" {
-                Get-Command getStarfieldPath | Should -HaveParameter symlink -Type switch
-                Get-Command getStarfieldPath | Should -HaveParameter symlink -Mandatory:$false
-            }
-        }
-
-        Context "functionality" {
-            It "should return the path with the prefix removed" {
-                getStarfieldPath |
-
-                Should -Be 'value1'
-                Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
-                Should -Invoke findRegistryKeys -ModuleName utils -Times 1
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-            }
-
-            It "should return the symlink path when pass symlink parameter" {
-                getStarfieldPath -symlink |
-
-                Should -Be 'symlink'
-                Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
-                Should -Invoke findRegistryKeys -ModuleName utils -Times 1
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-            }
-
-            It "should return $false the path doesn't exist" {
-                Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
-                
-                getStarfieldPath |
-
-                Should -BeFalse
-                Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
-                Should -Invoke findRegistryKeys -ModuleName utils -Times 1
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-            }
-        }
+    It "should have a setConfigProperty function" {
+        $moduleFunctions | Should -Contain 'setConfigProperty'
     }
 
-    Describe "getRegConfigPath" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+    Context "functionality" {
+        It "should create a new config file, if it doesn't already exist and store the given prop/val" {
+            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
 
-            Mock -ModuleName utils -CommandName 'getStarfieldPackage' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'Join-Path' -MockWith { return 'Path' }
-            Mock -ModuleName utils -CommandName 'logToFile'
+            setConfigProperty "key" "val" |
+
+            Should -Invoke Get-Content -ModuleName utils -Times 0
+            Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
+            Should -Invoke Out-File -ModuleName utils -Times 1
         }
 
-        It "should have a getRegConfigPath function" {
-            $moduleFunctions | Should -Contain 'getRegConfigPath'
-        }
-
-        Context "functionality" {
-            It "should return the path if exist" {
-                getRegConfigPath |
-
-                Should -Be 'Path'
-                Should -Invoke logToFile -ModuleName utils -Times 0
-            }
-
-            It "should return $false and write to log if it does NOT exist" {
-                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
-
-                getRegConfigPath |
-
-                Should -BeFalse
-                Should -Invoke logToFile -ModuleName utils -Times 1
-            }
-        }
-    }
-
-    Describe "sfseRegistryExists" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-
-            Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'logToFile'
-        }
-
-        It "should have a sfseRegistryExists function" {
-            $moduleFunctions | Should -Contain 'sfseRegistryExists'
-        }
-
-        Context "functionality" {
-            It "should return $true if exist" {
-                sfseRegistryExists |
-
-                Should -BeTrue
-                Should -Invoke logToFile -ModuleName utils -Times 0
-                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
-            }
-
-            It "should return $false and write to log if it does NOT exist" {
-                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
-
-                sfseRegistryExists |
-
-                Should -BeFalse
-                Should -Invoke logToFile -ModuleName utils -Times 1
-                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
-            }
-        }
-    }
-
-    Describe "backupGameReg" {
-        BeforeAll {
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            
-            $obj = [hashtable]@{
-                Version = "0.1.70.0";
-            }
-
+        It "should extend the config file if it exists and key/val does not" {
             Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $True }
-            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
-            Mock -ModuleName utils -CommandName 'logToFile'
 
-            Mock -ModuleName utils -CommandName 'New-Item'
-            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
-            Mock -ModuleName utils -CommandName 'reg'
+            setConfigProperty "key" "val" |
+
+            Should -Invoke Get-Content -ModuleName utils -Times 1
+            Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
+            Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
+            Should -Invoke Out-File -ModuleName utils -Times 1
+            Should -Invoke Add-Member -ModuleName utils -Times 1
         }
 
-        It "should have a backupGameReg function" {
-            $moduleFunctions | Should -Contain 'backupGameReg'
+        It "should replace the value of the property if it already exists in the config" {
+            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
+
+            setConfigProperty "gamePath" "C:\\XboxGames\\Starfield\\Content" |
+
+            Should -Invoke Get-Content -ModuleName utils -Times 1
+            Should -Invoke ConvertTo-Json -ModuleName utils -Times 1
+            Should -Invoke ConvertFrom-Json -ModuleName utils -Times 1
+            Should -Invoke Out-File -ModuleName utils -Times 1
+            Should -Invoke Add-Member -ModuleName utils -Times 0
         }
+    }
+}
 
-        Context "functionality" {
-            It "should call reg export" {
-                backupGameReg
+Describe "findRegistryKeys" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        $objArr = 'testKey1', 'testKey2'
 
-                Should -Invoke fileExists -ModuleName utils -Times 1
-                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-                Should -Invoke reg -ModuleName utils -Times 1
-            }
+        Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith { return $objArr }
+        Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+    }
 
-            It "should NOT call reg export if file exists" {
-                Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+    It "should have a findRegistryKeys function" {
+        $moduleFunctions | Should -Contain 'findRegistryKeys'
+    }
 
-                backupGameReg
-
-                Should -Invoke fileExists -ModuleName utils -Times 1
-                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
-                Should -Invoke findRegistryValues -ModuleName utils -Times 1
-                Should -Invoke Test-Path -ModuleName utils -Times 1
-                Should -Invoke reg -ModuleName utils -Times 0
-                Should -Invoke logToFile -ModuleName utils -Times 1
-            }
-
-            It "should create the folder if it doesn't exist" {
-                Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
-                
-                backupGameReg
-                Should -Invoke New-Item -ModuleName utils -Times 1
-            }
-            
-            It "should write to log if the game version is not found" {
-                Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
-
-                backupGameReg
-                Should -Invoke logToFile -ModuleName utils -Times 1
-            }
+    Context "parameters" {
+        It "should have a parameter named path" {
+            Get-Command findRegistryKeys | Should -HaveParameter path -Type String
+            Get-Command findRegistryKeys | Should -HaveParameter path -Mandatory:$false
         }
     }
 
-    Describe "setSFSERegistry" {
-        BeforeAll {
+    Context "functionality" {
+        It "should return the keys if they exist" {
+            findRegistryKeys "fake\registry\path" |
+
+            Should -eq 'testKey1', 'testKey2'
+            Should -Invoke Get-ChildItem -ModuleName utils -Times 1
+        }
+
+        It "should return $false if there are no keys in path" {
+            Mock -ModuleName utils -CommandName 'Get-ChildItem' -MockWith { return $False }
+            
+            findRegistryKeys "fake\registry\path" |
+
+            Should -BeFalse
+            Should -Invoke Get-ChildItem -ModuleName utils -Times 1
+        }
+
+        It "should write to log if the path does not exist" {
+            #Add global variable for logpath
             $global:LogPath = '/path/'
 
-            $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
-            $regConfigPath = 'path/to/reg'
-
-            Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $regConfigPath }
-            Mock -ModuleName utils -CommandName 'sfseRegistryExists' -MockWith { return $False }
-            Mock -ModuleName utils -CommandName 'backupGameReg'
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
             Mock -ModuleName utils -CommandName 'logToFile'
-            
-            Mock -ModuleName utils -CommandName 'Copy-Item'
-            Mock -ModuleName utils -CommandName 'Set-ItemProperty'
-            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
-        }
 
-        AfterAll {
+            findRegistryKeys "fake\registry\path" |
+
+            Should -BeFalse
+            Should -Invoke Get-ChildItem -ModuleName utils -Times 0
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1
+
             # Remove global variable
-            Remove-Variable -Name LogPath -Scope Global
+            Remove-Variable -name LogPath -Scope Global
+        }
+    }
+}
+
+Describe "findRegistryValues" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        $obj = [PSCustomObject]@{
+            key1 = "value1";
+            key2 = "value2";
         }
 
-        It "should have a setSFSERegistry function" {
-            $moduleFunctions | Should -Contain 'setSFSERegistry'
+        Mock -ModuleName utils -CommandName 'Get-ItemProperty' -MockWith { return $obj }
+        Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+    }
+
+    It "should have a findRegistryValues function" {
+        $moduleFunctions | Should -Contain 'findRegistryValues'
+    }
+
+    Context "parameters" {
+        It "should have a mandatory parameter named path" {
+            Get-Command findRegistryValues | Should -HaveParameter path -Type String
+            Get-Command findRegistryValues | Should -HaveParameter path -Mandatory:$true
+        }
+        It "should have an optional parameter named value" {
+            Get-Command findRegistryValues | Should -HaveParameter value -Type String
+            Get-Command findRegistryValues | Should -HaveParameter value -Mandatory:$false
+        }
+    }
+
+    Context "functionality" {
+        It "should return all values of reg key" {
+            $expected = @{key1 = 'value1'; key2 = 'value2' }
+            $result = findRegistryValues "fake\registry\path"
+
+            Assert-Equivalent -Actual $result -Expected $expected
+            Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
+            Should -Invoke Test-Path -ModuleName utils -Times 1
         }
 
-        Context "functionality" {
-            It "should copy and update the registry" {
-                setSFSERegistry
+        It "should return values matching the wildcard" {
+            $expected = @{key2 = 'value2' }
+            $result = findRegistryValues "fake\registry\path" "key2"
+            
+            Assert-Equivalent -Actual $result -Expected $expected
+            Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+        }
 
-                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
-                Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
-                Should -Invoke backupGameReg -ModuleName utils -Times 1
-                Should -Invoke Test-Path -ModuleName utils -Times 2
+        It "should return $false if there are no values" {
+            Mock -ModuleName utils -CommandName 'Get-ItemProperty' -MockWith { return $False }
+            
+            findRegistryValues "fake\registry\path" |
 
-                Should -Invoke Copy-Item -ModuleName utils -Times 1
-                Should -Invoke Set-ItemProperty -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1 
-            }
+            Should -BeFalse
+            Should -Invoke Get-ItemProperty -ModuleName utils -Times 1
+        }
 
-            It "should NOT copy and update the registry, if custom registry entry exists" {
-                Mock -ModuleName utils -CommandName 'sfseRegistryExists' -MockWith { return $True }
-                
-                setSFSERegistry
+        It "should write to log if the path does not exist" {
+            #Add global variable for logpath
+            $global:LogPath = '/path/'
 
-                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
-                Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1 
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+            Mock -ModuleName utils -CommandName 'logToFile'
 
-                Should -Invoke backupGameReg -ModuleName utils -Times 0
-                Should -Invoke Test-Path -ModuleName utils -Times 0
-                Should -Invoke Copy-Item -ModuleName utils -Times 0
-                Should -Invoke Set-ItemProperty -ModuleName utils -Times 0
-            }
+            findRegistryValues "fake\registry\path" |
 
-            It "should NOT copy and update the registry, if config path doesn't exist" {
-                Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $False }
-                
-                setSFSERegistry
+            Should -BeFalse
+            Should -Invoke Get-ItemProperty -ModuleName utils -Times 0
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1
 
-                Should -Invoke getRegConfigPath -ModuleName utils -Times 1
-                Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
-                Should -Invoke logToFile -ModuleName utils -Times 1 
+            # Remove global variable
+            Remove-Variable -name LogPath -Scope Global
+        }
+    }
+}
 
-                Should -Invoke backupGameReg -ModuleName utils -Times 0
-                Should -Invoke Test-Path -ModuleName utils -Times 0
-                Should -Invoke Copy-Item -ModuleName utils -Times 0
-                Should -Invoke Set-ItemProperty -ModuleName utils -Times 0
-            }
+Describe "getStarfieldPackage" {
+    BeforeAll {
+        #Add global variable for logpath
+        $global:pkgRegPath = 'fake/reg/path'
+        $global:LogPath = '/path/'
+            
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        $obj = [hashtable]@{
+            key1 = "value1";
+        }
+
+        Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+        Mock -ModuleName utils -CommandName 'logToFile'
+    }
+
+    AfterAll {
+        # Remove global variable
+        Remove-Variable -Name pkgRegPath -Scope Global
+        Remove-Variable -Name LogPath -Scope Global
+    }
+
+    It "should have a getStarfieldPackage function" {
+        $moduleFunctions | Should -Contain 'getStarfieldPackage'
+    }
+
+    Context "parameters" {
+        It "should have an optional parameter named key" {
+            Get-Command getStarfieldPackage | Should -HaveParameter key -Type switch
+            Get-Command getStarfieldPackage | Should -HaveParameter key -Mandatory:$false
+        }
+    }
+
+    Context "functionality" {
+        It "should return only the key if 'key' boolean is passed" {
+            getStarfieldPackage -key |
+            
+            Should -Be "key1"
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+        }
+
+        It "should return only the value if 'key' boolean not passed" {
+            getStarfieldPackage |
+            
+            Should -Be "value1"
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+        }
+
+        It "should return $false if the package doesn't exist" {
+            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
+            
+            getStarfieldPackage |
+
+            Should -BeFalse
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1
+        }
+
+        It "should write to log if the path does not exist" {
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+            Mock -ModuleName utils -CommandName 'logToFile'
+
+            getStarfieldPackage |
+
+            Should -BeFalse
+            Should -Invoke findRegistryValues -ModuleName utils -Times 0
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "getStarfieldPath" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        
+        $obj = [hashtable]@{
+            key1 = "\\?\value1";
+        }
+
+        $symObj = [PSCustomObject]@{Target = 'symlink/path' };
+
+        Mock -ModuleName utils -CommandName 'getStarfieldPackage' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'findRegistryKeys' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+        Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+        
+        Mock -ModuleName utils Get-Item -MockWith { return $symObj }
+        Mock -ModuleName utils Split-Path -ParameterFilter { $Path -eq $symObj.Target } -MockWith { return $symObj.Target | Split-Path }
+    }
+
+    It "should have a getStarfieldPath function" {
+        $moduleFunctions | Should -Contain 'getStarfieldPath'
+    }
+
+    Context "parameters" {
+        It "should have an optional parameter named symlink" {
+            Get-Command getStarfieldPath | Should -HaveParameter symlink -Type switch
+            Get-Command getStarfieldPath | Should -HaveParameter symlink -Mandatory:$false
+        }
+    }
+
+    Context "functionality" {
+        It "should return the path with the prefix removed" {
+            getStarfieldPath |
+
+            Should -Be 'value1'
+            Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
+            Should -Invoke findRegistryKeys -ModuleName utils -Times 1
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+        }
+
+        It "should return the symlink path when pass symlink parameter" {
+            getStarfieldPath -symlink |
+
+            Should -Be 'symlink'
+            Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
+            Should -Invoke findRegistryKeys -ModuleName utils -Times 1
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+        }
+
+        It "should return $false the path doesn't exist" {
+            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
+            
+            getStarfieldPath |
+
+            Should -BeFalse
+            Should -Invoke getStarfieldPackage -ModuleName utils -Times 1
+            Should -Invoke findRegistryKeys -ModuleName utils -Times 1
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "getRegConfigPath" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+
+        Mock -ModuleName utils -CommandName 'getStarfieldPackage' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'Join-Path' -MockWith { return 'Path' }
+        Mock -ModuleName utils -CommandName 'logToFile'
+    }
+
+    It "should have a getRegConfigPath function" {
+        $moduleFunctions | Should -Contain 'getRegConfigPath'
+    }
+
+    Context "functionality" {
+        It "should return the path if exist" {
+            getRegConfigPath |
+
+            Should -Be 'Path'
+            Should -Invoke logToFile -ModuleName utils -Times 0
+        }
+
+        It "should return $false and write to log if it does NOT exist" {
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+
+            getRegConfigPath |
+
+            Should -BeFalse
+            Should -Invoke logToFile -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "sfseRegistryExists" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+
+        Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'logToFile'
+    }
+
+    It "should have a sfseRegistryExists function" {
+        $moduleFunctions | Should -Contain 'sfseRegistryExists'
+    }
+
+    Context "functionality" {
+        It "should return $true if exist" {
+            sfseRegistryExists |
+
+            Should -BeTrue
+            Should -Invoke logToFile -ModuleName utils -Times 0
+            Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+        }
+
+        It "should return $false and write to log if it does NOT exist" {
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+
+            sfseRegistryExists |
+
+            Should -BeFalse
+            Should -Invoke logToFile -ModuleName utils -Times 1
+            Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "backupGameReg" {
+    BeforeAll {
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        
+        $obj = [hashtable]@{
+            Version = "0.1.70.0";
+        }
+
+        Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $True }
+        Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $obj }
+        Mock -ModuleName utils -CommandName 'logToFile'
+
+        Mock -ModuleName utils -CommandName 'New-Item'
+        Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $False }
+        Mock -ModuleName utils -CommandName 'reg'
+    }
+
+    It "should have a backupGameReg function" {
+        $moduleFunctions | Should -Contain 'backupGameReg'
+    }
+
+    Context "functionality" {
+        It "should call reg export" {
+            backupGameReg
+
+            Should -Invoke fileExists -ModuleName utils -Times 1
+            Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+            Should -Invoke reg -ModuleName utils -Times 1
+        }
+
+        It "should NOT call reg export if file exists" {
+            Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+
+            backupGameReg
+
+            Should -Invoke fileExists -ModuleName utils -Times 1
+            Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+            Should -Invoke findRegistryValues -ModuleName utils -Times 1
+            Should -Invoke Test-Path -ModuleName utils -Times 1
+            Should -Invoke reg -ModuleName utils -Times 0
+            Should -Invoke logToFile -ModuleName utils -Times 1
+        }
+
+        It "should create the folder if it doesn't exist" {
+            Mock -ModuleName utils -CommandName 'fileExists' -MockWith { return $False }
+            
+            backupGameReg
+            Should -Invoke New-Item -ModuleName utils -Times 1
+        }
+        
+        It "should write to log if the game version is not found" {
+            Mock -ModuleName utils -CommandName 'findRegistryValues' -MockWith { return $False }
+
+            backupGameReg
+            Should -Invoke logToFile -ModuleName utils -Times 1
+        }
+    }
+}
+
+Describe "setSFSERegistry" {
+    BeforeAll {
+        $global:LogPath = '/path/'
+
+        $moduleFunctions = (Get-Module -ListAvailable $modulePath).ExportedFunctions.Keys
+        $regConfigPath = 'path/to/reg'
+
+        Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $regConfigPath }
+        Mock -ModuleName utils -CommandName 'sfseRegistryExists' -MockWith { return $False }
+        Mock -ModuleName utils -CommandName 'backupGameReg'
+        Mock -ModuleName utils -CommandName 'logToFile'
+        
+        Mock -ModuleName utils -CommandName 'Copy-Item'
+        Mock -ModuleName utils -CommandName 'Set-ItemProperty'
+        Mock -ModuleName utils -CommandName 'Test-Path' -MockWith { return $True }
+    }
+
+    AfterAll {
+        # Remove global variable
+        Remove-Variable -Name LogPath -Scope Global
+    }
+
+    It "should have a setSFSERegistry function" {
+        $moduleFunctions | Should -Contain 'setSFSERegistry'
+    }
+
+    Context "functionality" {
+        It "should copy and update the registry" {
+            setSFSERegistry
+
+            Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+            Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
+            Should -Invoke backupGameReg -ModuleName utils -Times 1
+            Should -Invoke Test-Path -ModuleName utils -Times 2
+
+            Should -Invoke Copy-Item -ModuleName utils -Times 1
+            Should -Invoke Set-ItemProperty -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1 
+        }
+
+        It "should NOT copy and update the registry, if custom registry entry exists" {
+            Mock -ModuleName utils -CommandName 'sfseRegistryExists' -MockWith { return $True }
+            
+            setSFSERegistry
+
+            Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+            Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1 
+
+            Should -Invoke backupGameReg -ModuleName utils -Times 0
+            Should -Invoke Test-Path -ModuleName utils -Times 0
+            Should -Invoke Copy-Item -ModuleName utils -Times 0
+            Should -Invoke Set-ItemProperty -ModuleName utils -Times 0
+        }
+
+        It "should NOT copy and update the registry, if config path doesn't exist" {
+            Mock -ModuleName utils -CommandName 'getRegConfigPath' -MockWith { return $False }
+            
+            setSFSERegistry
+
+            Should -Invoke getRegConfigPath -ModuleName utils -Times 1
+            Should -Invoke sfseRegistryExists -ModuleName utils -Times 1
+            Should -Invoke logToFile -ModuleName utils -Times 1 
+
+            Should -Invoke backupGameReg -ModuleName utils -Times 0
+            Should -Invoke Test-Path -ModuleName utils -Times 0
+            Should -Invoke Copy-Item -ModuleName utils -Times 0
+            Should -Invoke Set-ItemProperty -ModuleName utils -Times 0
         }
     }
 }

--- a/src/cli/utils.psm1
+++ b/src/cli/utils.psm1
@@ -289,6 +289,26 @@ function refresh() {
     }
 }
 
+function isSamePath() {
+    param (
+        [Parameter(Mandatory)]
+        [string]$path
+    )
+
+    $gamePath = (getConfigProperty "gamePath")
+
+    if (!($gamePath)) {
+        $gamePath = getStarfieldPath
+        $gamePathSymLink = getStarfieldPath -symlink
+    }
+
+    if ($gamePath.Contains($path) -or ($gamePathSymLink -and $gamePathSymLink.Contains($path))) {
+        return $true
+    }
+
+    return $false
+}
+
 function findRegistryKeys() {
     param (
         [Parameter(Mandatory)]
@@ -388,7 +408,7 @@ function getStarfieldPath() {
                 $trimmedPath = $gameRoot.Values[0].replace("\\?\", "")
 
                 if ($symlink) {
-                    return (Get-Item $trimmedPath).Target | Split-Path
+                    return (Get-Item $trimmedPath).Target
                 }
                 else {
                     return  $trimmedPath
@@ -489,4 +509,9 @@ function removeSFSERegistry() {
             Remove-Item $sfseExePath
         }
     }
+}
+
+function setSFSEPath() {
+    $gamePathReg = getStarfieldPath -symlink
+    setConfigProperty "gamePath" $gamePathReg
 }

--- a/src/cli/utils.psm1
+++ b/src/cli/utils.psm1
@@ -1,6 +1,12 @@
 # Paths
 $rootPath = $PSScriptRoot | Split-Path
 $configPath = (Join-Path $rootPath 'config.json')
+$regBkPath = Join-Path $rootPath "reg"
+
+# reg paths
+$msRegPath = "HKLM:\SOFTWARE\Microsoft\GamingServices"
+$pkgRegPath = Join-Path $msRegPath "PackageRepository"
+$baseConfigPath = Join-Path $msRegPath "GameConfig"
 
 # Log
 $dateNow = $((Get-Date).ToString('yyyy.MM.dd_hh.mm.ss'))
@@ -171,7 +177,7 @@ function setConfigProperty() {
             $config = Get-Content -Raw $configPath | ConvertFrom-Json
 
             if (!$config.$property) {
-                $config | Add-Member @{$property = $value }
+                $config | Add-Member @{$property = $value } -Force
             }
             else {
                 $config.$property = $value
@@ -280,5 +286,207 @@ function refresh() {
     }
     catch {
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    }
+}
+
+function findRegistryKeys() {
+    param (
+        [Parameter(Mandatory)]
+        [string]$path
+    )
+
+    if (!(Test-Path -Path $path)) {
+        logToFile -Content "$path not found"
+        return $false
+    }
+
+    $results = @(Get-ChildItem -Path $path -Name)
+
+    if (!$results) {
+        return $false
+    }
+    else {
+        return $results
+    }
+}
+
+function findRegistryValues() {
+    param (
+        [Parameter(Mandatory)]
+        [String] $path,
+        [String] $value
+    )
+
+    if (!(Test-Path -Path $path)) {
+        logToFile -Content "$path not found"
+        return $false
+    }
+
+    $result = $false
+
+    if ($value) {
+        $result = Get-ItemProperty -Path $path | Select-Object "$value*"
+    }
+    else {
+        $result = Get-ItemProperty -Path $path
+    }
+
+    if (!$result) {
+        return $false
+    }
+    else {
+        $hashtable = @{}
+        $result.psobject.properties | ForEach-Object { $hashtable[$_.Name] = $_.Value }
+        return $hashtable
+    }
+}
+
+function getStarfieldPackage() {
+    param (
+        [Switch] $key
+    )
+
+    if (!(Test-Path -Path $pkgRegPath)) {
+        logToFile -Content "Microsoft Package registry not found"
+        return $false
+    }
+    else {
+        $installedPkgsPath = Join-Path $pkgRegPath "Package"
+        $packageKeyValues = findRegistryValues -path $installedPkgsPath -value "BethesdaSoftworks.ProjectGold"
+
+        if ($packageKeyValues) {
+            if ($key) {
+                return $packageKeyValues.keys[0]
+            }
+            else {
+                return $packageKeyValues.Values[0]
+            }
+        }
+        else {
+            logToFile -Content "Cannot retrieve path, starfield package not found in registry"
+            return $false
+        }
+    }
+}
+
+function getStarfieldPath() {
+    param (
+        [Switch] $symlink
+    )
+
+    $starfieldUniqueKey = getStarfieldPackage
+    if ($starfieldUniqueKey) {
+        $rootPath = Join-Path $pkgRegPath "Root"
+        $uniqueKeyPath = Join-Path $rootPath $starfieldUniqueKey
+        $gameRootKey = findRegistryKeys -path $uniqueKeyPath
+
+        if ($gameRootKey) {
+            $gameRootPath = Join-Path $uniqueKeyPath $gameRootKey
+            $gameRoot = findRegistryValues -path $gameRootPath -value "Root"
+
+            if ($gameRoot) {
+                $trimmedPath = $gameRoot.Values[0].replace("\\?\", "")
+
+                if ($symlink) {
+                    return (Get-Item $trimmedPath).Target | Split-Path
+                }
+                else {
+                    return  $trimmedPath
+                }
+            }
+            else {
+                return $false
+            }
+        }
+    }
+}
+
+function getRegConfigPath() {
+    $starfieldPackageKey = getStarfieldPackage -key
+    if ($starfieldPackageKey) {
+        $starfieldConfigPath = Join-Path $baseConfigPath $starfieldPackageKey
+        if (!(Test-Path -Path $starfieldConfigPath)) {
+            logToFile -Content "Starfield config reg key not found!"
+            return $false
+        }
+        else {
+            return $starfieldConfigPath
+        }
+    }
+}
+
+function sfseRegistryExists() {
+    $starfieldConfigPath = getRegConfigPath
+    if ($starfieldConfigPath) {
+        $sfseExePath = Join-Path (Join-Path $starfieldConfigPath "Executable") '00000001'
+        if (!(Test-Path -Path $sfseExePath)) {
+            logToFile -Content "SFSE registry entry does not exist!"
+            return $false
+        }
+        else {
+            return $true
+        }
+    }
+}
+
+function backupGameReg() {
+    if (!(fileExists $regBkPath)) {
+        New-Item -Path $rootPath -Name "reg" -ItemType "directory"
+    }
+
+    $starfieldConfigPath = getRegConfigPath
+    if ($starfieldConfigPath) {
+        $gameVersionVal = findRegistryValues -path $starfieldConfigPath -value "Version"
+        if ($gameVersionVal) {
+            $version = $gameVersionVal.Values[0]
+            $regFileName = "$version.reg"
+
+            if (!(Test-Path -Path (Join-Path $regBkPath $regFileName))) {
+                $regExpFriendlyPath = $starfieldConfigPath -replace ':', ''
+                reg export $regExpFriendlyPath (Join-Path $regBkPath $regFileName)
+            }
+            else {
+                logToFile -Content "Reg file backup exists, skipping."
+            }
+        }
+        else {
+            logToFile -Content "Cannot retrieve game version from registry"
+        }
+    }
+}
+
+function setSFSERegistry() {
+    $starfieldConfigPath = getRegConfigPath
+    if (!(sfseRegistryExists) -and $starfieldConfigPath) {
+        $gameExePath = Join-Path (Join-Path $starfieldConfigPath "Executable") '00000000'
+        $sfseExePath = Join-Path (Join-Path $starfieldConfigPath "Executable") '00000001'
+
+        # Backup reg if not already
+        backupGameReg
+
+        if ((Test-Path -Path $gameExePath)) {
+            Copy-Item $gameExePath $sfseExePath
+
+            if (Test-Path -Path $sfseExePath) {
+                Set-ItemProperty -Path $sfseExePath -Name "Name" -Value "sfse_loader.exe"
+                logToFile -Content "SFSE registry added successfully!"
+            }
+        }
+    }
+    else {
+        logToFile -Content "SFSE registry already exists, skipping!"
+    }
+}
+
+function removeSFSERegistry() {
+    $starfieldConfigPath = getRegConfigPath
+    if ($starfieldConfigPath) {
+        $sfseExePath = Join-Path (Join-Path $starfieldConfigPath "Executable") '00000001'
+        if (!(Test-Path -Path $sfseExePath)) {
+            logToFile -Content "SFSE registry entry does not exist!"
+        }
+        else {
+            Remove-Item $sfseExePath
+        }
     }
 }


### PR DESCRIPTION
- SFSE can now be launched via winstore shortcut, making a duplicate of game files is no longer required.
- Added additional tests
- Updated CLI to grab game path automatically and make registry bypass the default in Auto install
- Additional fixes and refactoring